### PR TITLE
Added bower.json so flexText can be registered as a bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,26 @@
+{
+  "name": "flexText",
+  "version": "0.0.0",
+  "homepage": "http://alexdunphy.github.io/flexText/",
+  "authors": [
+    "Alex Dunphy - https://github.com/alexdunphy"
+  ],
+  "description": "A lightweight jQuery plugin for auto-height textareas.",
+  "main": "jquery.flexText.min.js",
+  "keywords": [
+    "flex",
+    "text",
+    "flextext",
+    "flex-text",
+    "flexible",
+    "textarea",
+    "textareas"
+  ],
+  "ignore": [
+    "**/.*",
+    "demo"
+  ],
+  "dependencies": {
+    "jquery": "1.9.1"
+  }
+}


### PR DESCRIPTION
Already registered it, too. Hope that's not a problem! It's now installable with the following bower command:

`bower install flexText`

You might want to check what I've done, and maybe update the README.md to reflect the new bower package if you're happy with it.
